### PR TITLE
Target .NET 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ![GitHub license](https://img.shields.io/github/license/Metacinnabar/xincraftsharp)
 ![GitHub last commit](https://img.shields.io/github/last-commit/Metacinnabar/xincraftsharp)
 
-**An API wrapper for the [XinCraft public API](https://github.com/XinCraft/docs), written in C# .NET 6.**
+**An API wrapper for the [XinCraft public API](https://github.com/XinCraft/docs), written in C# .NET 5, compatible with .NET 5+.**
 - If you found **XinCraftSharp** helpful or neat please consider leaving a star ⭐
 
 ## Documentation     

--- a/XinCraftSharp/XinCraftSharp.csproj
+++ b/XinCraftSharp/XinCraftSharp.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
+        <TargetFramework>net5.0</TargetFramework>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 


### PR DESCRIPTION
Target .NET 5 instead of .NET 6 to allow the library to work with .NET 5 and .NET 6 projects.
The example project still targets .NET 6 to show the compatibility.